### PR TITLE
Dockerfile: upgrade to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y upgrade && \
 #
 # Add PPA for Python 3.x and R 4.0
-apt -y install software-properties-common dirmngr && \
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
+apt-get -y install \
+  ca-certificates \
+  curl \
+  dirmngr \
+  gpg \
+  software-properties-common && \
+curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xE298A3A825C0D65DFD57CBB651716619E084DAB9" | gpg --dearmor -o /etc/apt/keyrings/r-project-keyring.gpg && \
 add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)-cran40/" && \
 add-apt-repository -y ppa:deadsnakes/ppa && \
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #                         Fabian Lehmann
 #                         Wilfried Weber
 
-FROM ubuntu:20.04 as builder
+FROM ubuntu:20.04 AS builder
 
 # disable interactive frontends
 ENV DEBIAN_FRONTEND=noninteractive 
@@ -90,7 +90,9 @@ Rscript -e "pak::pkg_install(c('rmarkdown','plotly', 'stringi', 'stringr', 'tm',
 apt-get clean && rm -r /var/cache/ /root/.cache /tmp/Rtmp*
 
 # Install folder
-ENV INSTALL_DIR /opt/install/src
+ENV INSTALL_DIR=/opt/install/src \
+    HOME=/home/docker \
+    PATH="$PATH:/home/docker/bin"
 
 # Build OpenCV from source
 RUN mkdir -p $INSTALL_DIR/opencv && cd $INSTALL_DIR/opencv && \
@@ -130,8 +132,5 @@ RUN groupadd docker && \
   mkdir -p /home/docker/bin && chown docker /home/docker/bin
 # Use this user by default
 USER docker
-
-ENV HOME /home/docker
-ENV PATH "$PATH:/home/docker/bin"
 
 WORKDIR /home/docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,31 +75,14 @@ pip3 install --no-cache-dir  \
     git+https://github.com/ernstste/landsatlinks.git && \
 #
 # Install R packages
-Rscript -e 'install.packages("rmarkdown",   repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("plotly",      repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("stringi",     repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("stringr",     repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("tm",          repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("knitr",       repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("dplyr",       repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("bib2df",      repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("wordcloud",   repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("wordcloud2",   repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("network",     repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("intergraph",  repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("igraph",      repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("htmlwidgets", repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("raster",      repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("sp",          repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("rgdal",       repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("units",       repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("sf",          repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("snow",        repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("snowfall",    repos="https://cloud.r-project.org")' && \
-Rscript -e 'install.packages("getopt",      repos="https://cloud.r-project.org")' && \
+Rscript -e "install.packages(c('sp', 'https://cran.r-project.org/src/contrib/Archive/rgdal/rgdal_1.6-7.tar.gz'), repos='https://cloud.r-project.org', Ncpus=4)" && \
+Rscript -e "install.packages('pak', repos='https://r-lib.github.io/p/pak/dev/')" && \
+CORES=$(nproc) && \
+export MAKEFLAGS="-j$CORES" && \
+Rscript -e "pak::pkg_install(c('rmarkdown','plotly', 'stringi', 'stringr', 'tm', 'knitr', 'dplyr', 'bib2df', 'wordcloud', 'wordcloud2', 'network', 'intergraph','igraph', 'htmlwidgets', 'raster', 'units', 'sf', 'snow', 'snowfall', 'getopt'))" && \
 #
 # Clear installation data
-apt-get clean && rm -r /var/cache/
+apt-get clean && rm -r /var/cache/ /root/.cache /tmp/Rtmp*
 
 # Install folder
 ENV INSTALL_DIR /opt/install/src


### PR DESCRIPTION
Switch to Ubuntu 24.04, bump some
versions of dependencies, and use
some of the packages from Ubuntu
instead of building OpenCV manually.

There is also an ubuntu user/group
by default in the base image, so
use that instead of creating
a separate docker user like before.

Rebuilding the image revealed that
rgdal was no longer available
on CRAN, so update the R package
installation to install rgdal from
the archive, and install the other
packages in parallel.