### PR TITLE
Dockerfile: support UID/GID != 1000

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.github
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install folder for custom builds
 ENV INSTALL_DIR=/opt/install/src
 
+# Add login-script for UID/GID-remapping.
+COPY --chown=root:root --link remap-user.sh /usr/local/bin/remap-user.sh
+
 # Refresh package list & upgrade existing packages
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -46,6 +49,7 @@ apt-get -y install \
   git \
   build-essential \
   cmake \
+  gosu \
   libgsl0-dev \
   libjansson-dev \
   libssl-dev \
@@ -61,6 +65,7 @@ apt-get -y install \
   python-is-python3 \
   parallel \
   r-base \
+  tini \
   aria2
 
 # Install Python packages
@@ -130,3 +135,7 @@ ENV HOME=/home/ubuntu \
 USER ubuntu
 
 WORKDIR /home/ubuntu
+
+USER root
+
+ENTRYPOINT ["/usr/local/bin/remap-user.sh"]

--- a/remap-user.sh
+++ b/remap-user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+# Script that gives the container user uid $LOCAL_UID and gid $LOCAL_GID.
+# If $LOCAL_UID or $LOCAL_GID are not set, they default to 1000 (default
+# for the first user created in Ubuntu).
+
+USER_ID=${LOCAL_UID:-1000}
+GROUP_ID=${LOCAL_GID:-1000}
+
+[[ "$USER_ID" == "1000" ]] || usermod -u $USER_ID -o -m -d /home/ubuntu ubuntu
+[[ "$GROUP_ID" == "1000" ]] || groupmod -g $GROUP_ID ubuntu
+[[ $(id -u) != "0" ]] || GOSU="/usr/sbin/gosu ubuntu"
+exec /usr/bin/tini -- $GOSU "$@"


### PR DESCRIPTION
Make it possible to use the image with a different UID/GID than 1000 by changing the UID/GID inside the container.

Also install tini and use that so zombies are reaped and signals are forwarded.

I don't want to flood you with a million PRs so this PR also contains an unrelated commit that adds a `.dockerignore`. The ignores ensure Docker doesn't copy those things into the build context, which saves time and ensures those things can't invalidate the Docker cache. The commit message contains one way to check what is picked up by the `.dockerignore`.