### PR TITLE
Dockerfile: stop installing key for R 4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,7 @@ ENV INSTALL_DIR=/opt/install/src
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
   apt-get -y update && apt-get -y upgrade && \
-#
-# Install wget and add Key for R 4.0
-apt-get -y install \
-  wget && \
-  wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | \
-  tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc && \
-#
-# Install remaining required tools
+# Install required tools.
 apt-get -y install \
   ca-certificates \
   dirmngr \
@@ -61,6 +54,7 @@ apt-get -y install \
   python-is-python3 \
   parallel \
   r-base \
+  wget \
   aria2
 
 # Install Python packages


### PR DESCRIPTION
The r-base package in Ubuntu 24.04 contains
R 4.3.3, so there shouldn't be a need for
any extra key. Beyond that, there is no
apt-get update done between adding the key
and installing the packages and there is no
edit of any sources.list to point to the key,
so this key is most likely unused.