### PR TITLE
Dockerfile: do not pip install gdal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ RUN pip3 install --break-system-packages --no-cache-dir \
     numpy \
     gsutil \
     scipy \
-    gdal==$(gdal-config --version) \
     git+https://github.com/ernstste/landsatlinks.git && \
 #
 # Install R packages


### PR DESCRIPTION
The GDAL image already contains
the Python support, so stop installing
the package from PyPi that uses
some other GDAL version.

Refs https://github.com/davidfrantz/force/issues/402