### PR TITLE
Speed up build of R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
 
 FROM internal_base AS builder
 
-# disable interactive frontends
-ENV DEBIAN_FRONTEND=noninteractive 
 
 # Install folder for custom builds
 ENV INSTALL_DIR=/opt/install/src
@@ -31,7 +29,9 @@ COPY --chown=root:root --link remap-user.sh /usr/local/bin/remap-user.sh
 # Refresh package list & upgrade existing packages
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  apt-get -y update && apt-get -y upgrade && \
+# Disable interactive frontends.
+export DEBIAN_FRONTEND=noninteractive && \
+apt-get -y update && apt-get -y upgrade && \
 # Install required tools.
 apt-get -y install \
   ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ apt-get -y update && apt-get -y upgrade && \
 apt-get -y install \
   ca-certificates \
   ccache \
+  curl \
   dirmngr \
   gpg \
   software-properties-common \
@@ -91,7 +92,7 @@ rm -rf $HOME/.R $HOME/.config/ccache && \
 #
 # Build OpenCV from source, only required parts
 mkdir -p $INSTALL_DIR/opencv && cd $INSTALL_DIR/opencv && \
-wget https://github.com/opencv/opencv/archive/4.12.0.zip \
+curl -LO -fsS https://github.com/opencv/opencv/archive/4.12.0.zip \
   && unzip 4.12.0.zip && \
 mkdir -p $INSTALL_DIR/opencv/opencv-4.12.0/build && \
 cd $INSTALL_DIR/opencv/opencv-4.12.0/build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ rm -rf $HOME/.R $HOME/.config/ccache && \
 # Build OpenCV from source, only required parts
 mkdir -p $INSTALL_DIR/opencv && cd $INSTALL_DIR/opencv && \
 curl -LO -fsS https://github.com/opencv/opencv/archive/4.12.0.zip \
-  && unzip 4.12.0.zip && \
+  && unzip -q 4.12.0.zip && \
 mkdir -p $INSTALL_DIR/opencv/opencv-4.12.0/build && \
 cd $INSTALL_DIR/opencv/opencv-4.12.0/build && \
 cmake \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,13 @@ echo -n "CCACHE=ccache\nCC=\$(CCACHE) gcc\nCXX=\$(CCACHE) g++\nCXX11=\$(CCACHE) 
 echo -n "max_size = 200M\nsloppiness = include_file_ctime\nhash_dir = false\n" > $HOME/.config/ccache/ccache.conf && \
 Rscript -e 'install.packages("rmarkdown", Ncpus = parallel::detectCores(), repos="https://cloud.r-project.org"); if (!library(rmarkdown, logical.return=T)) quit(save="no", status=10)' && \
 Rscript -e 'install.packages("plotly", Ncpus = parallel::detectCores(), repos="https://cloud.r-project.org"); if (!library(plotly, logical.return=T)) quit(save="no", status=10)' && \
+# The s2 package builds abseil as part of its installation, and that takes
+# a long time, so pass MAKEFLAGS so all available cores are used for
+# the abseil build.
+export MAKEFLAGS="-j$(nproc)" && \
+# Do NOT pass Ncpus, that limits the abseil compile to using a single core.
+Rscript -e 'install.packages("s2", repos="https://cloud.r-project.org"); if (!library(s2, logical.return=T)) quit(save="no", status=10)' && \
+unset MAKEFLAGS && \
 # sf: gdal dependency issues, disabled for now
 #Rscript -e 'install.packages("sf", repos="https://cloud.r-project.org"); if (!library(sf, logical.return=T)) quit(save="no", status=10)' && \
 Rscript -e 'install.packages("snow", Ncpus = parallel::detectCores(), repos="https://cloud.r-project.org"); if (!library(snow, logical.return=T)) quit(save="no", status=10)' && \


### PR DESCRIPTION
Use ccache when building the R packages, and make the build of abseil use all available cores.

Time for the installation of R packages and OpenCV with commit 5138059f6 on my local computer:

real 562.49
user 1.82
sys 3.46

Time for the same part with a warm cache for this branch:

real 103.25
user 0.37
sys 0.67

The CI does not preserve the ccache between builds, so only the speedup of building abseil will be noticeable there.

Also throw in a couple of commits that reduce the amount of output when downloading and unpacking OpenCV.