### PR TITLE
Dockerfile: use ccache for abseil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,8 @@ export MAKEFLAGS="-j$(nproc)" && \
 export CMAKE_C_COMPILER_LAUNCHER=ccache && \
 export CMAKE_CXX_COMPILER_LAUNCHER=ccache && \
 # Do NOT pass Ncpus, that limits the abseil compile to using a single core.
-Rscript -e 'install.packages("s2", repos="https://cloud.r-project.org"); if (!library(s2, logical.return=T)) quit(save="no", status=10)' && \
+# s2: required by sf which has gdal dependency issues, disable for now.
+#Rscript -e 'install.packages("s2", repos="https://cloud.r-project.org"); if (!library(s2, logical.return=T)) quit(save="no", status=10)' && \
 unset MAKEFLAGS CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER && \
 # sf: gdal dependency issues, disabled for now
 #Rscript -e 'install.packages("sf", repos="https://cloud.r-project.org"); if (!library(sf, logical.return=T)) quit(save="no", status=10)' && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,9 +88,11 @@ Rscript -e 'install.packages("plotly", Ncpus = parallel::detectCores(), repos="h
 # a long time, so pass MAKEFLAGS so all available cores are used for
 # the abseil build.
 export MAKEFLAGS="-j$(nproc)" && \
+export CMAKE_C_COMPILER_LAUNCHER=ccache && \
+export CMAKE_CXX_COMPILER_LAUNCHER=ccache && \
 # Do NOT pass Ncpus, that limits the abseil compile to using a single core.
 Rscript -e 'install.packages("s2", repos="https://cloud.r-project.org"); if (!library(s2, logical.return=T)) quit(save="no", status=10)' && \
-unset MAKEFLAGS && \
+unset MAKEFLAGS CMAKE_C_COMPILER_LAUNCHER CMAKE_CXX_COMPILER_LAUNCHER && \
 # sf: gdal dependency issues, disabled for now
 #Rscript -e 'install.packages("sf", repos="https://cloud.r-project.org"); if (!library(sf, logical.return=T)) quit(save="no", status=10)' && \
 Rscript -e 'install.packages("snow", Ncpus = parallel::detectCores(), repos="https://cloud.r-project.org"); if (!library(snow, logical.return=T)) quit(save="no", status=10)' && \


### PR DESCRIPTION
Abseil is a C++ library, so that does
not use the settings from
R's Makevars. Set some variables
so CMake starts using ccache, which
makes local image builds with
a warm cache quite a bit faster.

Also disable the s2 build per https://github.com/davidfrantz/base_image/pull/13#issuecomment-3760730846 since that is only required by sf.