### PR TITLE
Dockerfile: remove unused package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ apt-get -y install \
   curl \
   dirmngr \
   gpg \
-  software-properties-common \
   dos2unix \
   git \
   build-essential \


### PR DESCRIPTION
The software-properties-common
was added in #4 as part of
the Ubuntu version upgrade.
The current image does not
use add-apt-repository, so
remove the now unused package.

This reduces the image size
by ~3MB.