### PR TITLE
Dockerfile: fix image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ apt-get -y install --no-install-recommends \
   gosu \
   libgsl0-dev \
   libjansson-dev \
+  libuv1-dev \
   lockfile-progs \
   rename \
   pkgconf \


### PR DESCRIPTION
The installation of rmarkdown
suddenly started failing yesterday
because the fs package it depends
on got updated. Install libuv1-dev
so the installation works again.