### PR TITLE
Dockerfile: move cmake to build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,15 @@ apt-get -y install --no-install-recommends \
   # clone/install from git repositories
   # might not be necessary anymore
   #git \
-  # speed up building, likely only effective for local builds
+  # speed up building, only effective for local builds
   ccache \
   # GCC compiler etc.
   build-essential \
   # build requirement for OpenCV
   cmake \
-  # build requirement for OpenCV
+  # build requirement for OpenCV/FORCE
   pkgconf \
-  # not sure
+  # switching UID/GID inside container (for permissions)
   gosu \
   # Numerical library, dynamically linked in FORCE
   libgsl0-dev \
@@ -67,7 +67,7 @@ apt-get -y install --no-install-recommends \
   r-base \
   # used in all multiprocessing programs
   parallel \
-  # wrap entrypoints calls
+  # reaping of zombie processes
   tini
 
 FROM internal_base AS opencv_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,6 @@ export DEBIAN_FRONTEND=noninteractive && \
 apt-get -y update && apt-get -y upgrade && \
 # Install required tools.
 apt-get -y install --no-install-recommends \
-  # might not be necessary anymore? not sure why they are here
-  #ca-certificates \
-  #dirmngr \
-  #gpg \
   # clone/install from git repositories
   # might not be necessary anymore
   #git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,6 @@ apt-get -y install --no-install-recommends \
   ccache \
   # GCC compiler etc.
   build-essential \
-  # build requirement for OpenCV
-  cmake \
   # build requirement for OpenCV/FORCE
   pkgconf \
   # switching UID/GID inside container (for permissions)
@@ -80,6 +78,8 @@ export DEBIAN_FRONTEND=noninteractive && \
 apt-get -y update && apt-get -y upgrade && \
 apt-get install -y --no-install-recommends \
   ccache \
+  # build requirement for OpenCV
+  cmake \
   ninja-build \
   python3-pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,6 @@ export DEBIAN_FRONTEND=noninteractive && \
 apt-get -y update && apt-get -y upgrade && \
 # Install required tools.
 apt-get -y install --no-install-recommends \
-  # clone/install from git repositories
-  # might not be necessary anymore
-  #git \
   # speed up building, only effective for local builds
   ccache \
   # GCC compiler etc.


### PR DESCRIPTION
This is used for building OpenCV,
so not a required package for
downstream.

Also add a couple of commits that update
the comments and remove the unused
packages with an explanation of where
they came from and why they are no
longer needed.